### PR TITLE
Allow custom orchard inject string

### DIFF
--- a/src/build-app-output/index.js
+++ b/src/build-app-output/index.js
@@ -1,5 +1,4 @@
 import ac from 'argument-contracts';
-import { ORCHARD_INJECT_STRING } from '../constants';
 import { checkForRequiredInitialization } from './check-for-required-initialization';
 import { CliOptions, DO_NOT_INJECT } from '../cli-options';
 import fs from 'fs';
@@ -108,7 +107,7 @@ export async function buildAppOutput(cliOptions) {
 
     if (cliOptions.injectFile && cliOptions.injectFile !== DO_NOT_INJECT) {
         const fileContentToInjectInto = fs.readFileSync(cliOptions.injectFile, { encoding: 'utf8' });
-        const updatedFileContent = fileContentToInjectInto.replace(ORCHARD_INJECT_STRING, output);
+        const updatedFileContent = fileContentToInjectInto.replace(cliOptions.orchardInjectString, output);
         fs.writeFileSync(cliOptions.outputFile, updatedFileContent);
     } else {
         fs.writeFileSync(cliOptions.outputFile, output);

--- a/src/build-app-output/index.spec.js
+++ b/src/build-app-output/index.spec.js
@@ -43,6 +43,7 @@ describe('build app output', () => {
             excludeDirectDependencies: false,
             dependencyDirectory: 'her/there/everywhere',
             openFileLimit: 4,
+            orchardInjectString: '<!-- wat -->',
             outputFile: 'plumbus.html',
             retryOpenFileSleepDuration: 10
         });
@@ -189,10 +190,11 @@ describe('build app output', () => {
         });
 
         it('should inject output into the file', async () => {
+            const orchardInjectString = 'watwatwatwatwat';
             const outputFile = 'The best output';
             const beforeInjectionLocation = 'This file has been injected into!';
             const afterInjectionLocation = 'YEAH BOIIIIIIIIIII!';
-            const fileContent = `${beforeInjectionLocation}${ORCHARD_INJECT_STRING}${afterInjectionLocation}`;
+            const fileContent = `${beforeInjectionLocation}${orchardInjectString}${afterInjectionLocation}`;
             const output = 'The greatest output Evar';
             fs.readFileSync.and.returnValue(fileContent);
             ResolveRequiredDependencyScriptTagsModule.resolveRequiredDependencyScriptTags.and.returnValue([output])
@@ -200,6 +202,7 @@ describe('build app output', () => {
             await buildAppOutput({
                 ...cliOptions,
                 injectFile: 'yarp.txt',
+                orchardInjectString,
                 outputFile
             });
 

--- a/src/cli-options/index.js
+++ b/src/cli-options/index.js
@@ -1,4 +1,5 @@
 import ac from 'argument-contracts';
+import { ORCHARD_INJECT_STRING } from '../constants';
 import { LOGGING_LEVEL } from '../logger';
 
 export const DO_NOT_INJECT = '**%%DO_NOT_INJECT%%**';
@@ -9,7 +10,7 @@ export class CliOptions {
         injectFile = DO_NOT_INJECT,
         logging,
         openFileLimit,
-        orchardInjectString,
+        orchardInjectString = ORCHARD_INJECT_STRING,
         outputFile,
         pathToPackageJson = 'package.json',
         retryOpenFileSleepDuration

--- a/src/cli-options/index.js
+++ b/src/cli-options/index.js
@@ -9,6 +9,7 @@ export class CliOptions {
         injectFile = DO_NOT_INJECT,
         logging,
         openFileLimit,
+        orchardInjectString,
         outputFile,
         pathToPackageJson = 'package.json',
         retryOpenFileSleepDuration
@@ -16,6 +17,7 @@ export class CliOptions {
         ac.assertString(injectFile, 'injectFile');
         ac.assertString(dependencyDirectory, 'dependencyDirectory');
         ac.assertNumber(openFileLimit, 'openFileLimit');
+        ac.assertString(orchardInjectString, 'orchardInjectString');
         ac.assertString(outputFile, 'outputFile');
         ac.assertString(pathToPackageJson, 'pathToPackageJson');
         ac.assertNumber(retryOpenFileSleepDuration, 'retryOpenFileSleepDuration');
@@ -29,6 +31,7 @@ export class CliOptions {
         this.injectFile = injectFile;
         this.logging = safeLogging;
         this.openFileLimit = openFileLimit;
+        this.orchardInjectString = orchardInjectString;
         this.outputFile = outputFile;
         this.pathToPackageJson = pathToPackageJson;
         this.retryOpenFileSleepDuration = retryOpenFileSleepDuration;

--- a/src/cli-options/index.spec.js
+++ b/src/cli-options/index.spec.js
@@ -10,6 +10,7 @@ describe('cli options', () => {
             injectFile: 'starting/point/of/file.txt',
             logging: LOGGING_LEVEL.SILENT,
             openFileLimit: 0,
+            orchardInjectString: '<!-- things -->',
             outputFile: 'places/and/things.txt',
             pathToPackageJson: 'here/be/package.json',
             retryOpenFileSleepDuration: 1
@@ -74,6 +75,14 @@ describe('cli options', () => {
         new CliOptions(options);
 
         expect(ac.assertNumber).toHaveBeenCalledWith(options.openFileLimit, 'openFileLimit');
+    });
+
+    it('should asset orchardInjectString is a string', () => {
+        spyOn(ac, 'assertString');
+
+        new CliOptions(options);
+
+        expect(ac.assertString).toHaveBeenCalledWith(options.orchardInjectString, 'orchardInjectString');
     });
 
     it('should assert outputFile is a string', () => {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -30,6 +30,10 @@ sywac
     .string('-i, --injectFile', {
         desc: `The file to inject script tags into. Replaces well known string "${ORCHARD_INJECT_STRING}"`
     })
+    .string('-s, --orchardInjestString', {
+        desc: 'The string in your index file to be replaced with script tags.',
+        defaultValue: ORCHARD_INJECT_STRING
+    })
     .number('--openFileLimit', {
         desc: 'The maximum number of files to have open when doing many simultaneous operations (e.g. reading package.json files)',
         defaultValue: 4000


### PR DESCRIPTION
# Thanks for opening a Pull Request

## Changes

Please outline the reason for the changes you are making:

- Adding a cli option to provide a custom string that will be replaced by script tags
  - Allows for customizability and eliminated potential conflicts

Are there any breaking changes you are aware of in the PR?

No

## General Checklist

* [x] Change is tested locally
* ~Demo is updated to exercise change (if applicable)~
* [x] [WIP] flag is removed from the title

[1]:https://docs.npmjs.com/about-semantic-versioning
[2]:https://docs.npmjs.com/cli/deprecate
[3]:https://github.com/meltwater/applet-orchard/blob/master/docs/README.md
